### PR TITLE
npm cache of esm is faulty, breaks coverage 

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "serve": "^11.3.0"
   },
   "scripts": {
-    "coverage": "nyc --reporter=text --reporter=html --reporter=lcov npm run mocha",
-    "coveralls": "nyc npm run mocha && nyc report --reporter=text-lcov | coveralls",
+    "coverage": "rm -rf node_modules/.cache/esm && nyc --reporter=text --reporter=html --reporter=lcov npm run mocha",
+    "coveralls": "rm -rf node_modules/.cache/esm && nyc npm run mocha && nyc report --reporter=text-lcov | coveralls",
     "coverage:serve": "npm run coverage && serve coverage",
     "lint": "eslint ./src ./test",
     "lint:fix": "eslint ./src ./test --fix",


### PR DESCRIPTION
what was happening:
`rm -rf node_modules ; npm i ; npm test ; npm run coverage` failed
`rm -rf node_modules ; npm i ; npm run coverage` succeeded

similar bug is discussed here:
https://github.com/standard-things/esm/issues/746

`npm cache clear --force` did *not* work. But deleting `node_modules/.cache/esm` the problem goes away.

Note: this same problem can also cause issues with debugging, where the source code shown doesn't line up with what's going on.